### PR TITLE
fix clean() crash when missing raspbian dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 sandbox.js
 raspbian
+raspberrypi/

--- a/install.js
+++ b/install.js
@@ -18,7 +18,6 @@ exec('which qemu-arm-static', function (err, stdout) {
 
   exec('which systemd-nspawn', function (err, stdout) {
     if (err || !stdout) throw new Error('systemd-nspawn is required')
-
     clear()
     get(raspbian, function (err, res) {
       if (err || res.statusCode !== 200) throw new Error('Could not download raspbian')
@@ -42,6 +41,9 @@ exec('which qemu-arm-static', function (err, stdout) {
 })
 
 function clear () {
+  if (fs.existsSync(dir) === false) {
+    return
+  }
   fs.readdirSync(dir).forEach(function (name) {
     try {
       fs.unlinkSync(path.join(dir, name))

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "ansi-diff": "^1.1.1",
+    "mount-img": "^1.2.0",
     "prettier-bytes": "^1.0.4",
     "pump": "^3.0.0",
     "simple-get": "^3.0.3",

--- a/run.js
+++ b/run.js
@@ -11,6 +11,10 @@ const img = path.join(raspbian, fs.readdirSync(raspbian).filter(x => /\.img$/.te
 
 const qemu = execSync('which qemu-arm-static').toString().trim()
 
+if (fs.existsSync(mnt) === false) {
+  fs.mkdirSync(mnt)
+}
+
 spawnSync(mount, ['-p', '2', '-f', img, mnt], {
   stdio: 'inherit'
 })


### PR DESCRIPTION
```
$ npm install -g raspberry-pi-container
/home/bencevans/.nvm/versions/node/v8.12.0/bin/raspberry-pi-container -> /home/bencevans/.nvm/versions/node/v8.12.0/lib/node_modules/raspberry-pi-container/run.js

> raspberry-pi-container@1.0.0 install /home/bencevans/.nvm/versions/node/v8.12.0/lib/node_modules/raspberry-pi-container
> node install.js

fs.js:904
  return binding.readdir(pathModule._makeLong(path), options.encoding);
                 ^

Error: ENOENT: no such file or directory, scandir '/home/bencevans/.nvm/versions/node/v8.12.0/lib/node_modules/raspberry-pi-container/raspbian'
    at Object.fs.readdirSync (fs.js:904:18)
    at clear (/home/bencevans/.nvm/versions/node/v8.12.0/lib/node_modules/raspberry-pi-container/install.js:45:6)
    at /home/bencevans/.nvm/versions/node/v8.12.0/lib/node_modules/raspberry-pi-container/install.js:22:5
    at ChildProcess.exithandler (child_process.js:268:7)
    at emitTwo (events.js:126:13)
    at ChildProcess.emit (events.js:214:7)
    at maybeClose (internal/child_process.js:915:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:209:5)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! raspberry-pi-container@1.0.0 install: `node install.js`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the raspberry-pi-container@1.0.0 install script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/bencevans/.npm/_logs/2018-12-05T15_11_01_220Z-debug.log
```